### PR TITLE
Fixes dispatch times when only one animation is added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AnimationSequence
 
-SwiftUI tool that allows building complex sequence of animations more easily by hiding animation dispatching details.
+SwiftUI tool that allows building animation sequences more easily by hiding dispath queues details complexity.
 
 ## Platforms
 - iOS(.v13)
@@ -18,7 +18,6 @@ SwiftUI tool that allows building complex sequence of animations more easily by 
 
 `AnimationSequence` is meant to be flexible enough to allow you write more readable code. Here you have some many examples of what it looks like to write animation sequences. As almost all parameters are optional and nil by default(similar to SwiftUI syntax), it will let you write animation blocks more easily.
 
-
 ### Default values
 AnimationSequence init function takes optional arguments, they will default to `AnimationDefaults`.
 In this sample, two animation blocks are added to the sequence, and the start function is called at the end.
@@ -26,11 +25,11 @@ In this sample, two animation blocks are added to the sequence, and the start fu
 ```swift
 // takes the default values and applies it to all animations in the chain
 AnimationSequence()
-    .append {
+    .add {
         state.offsetX = 10
         state.color = .red
     }
-    .append {
+    .add {
         state = AnimationState()
     }
     .start()
@@ -41,12 +40,12 @@ When creating an instance of AnimationSequence with parameters, those will be ap
 
 ```swift
 // Set values for all animations in the chain
-AnimationSequence(duration: 0.5, delay: 0, easing: .default)
-    .append {
+AnimationSequence(delay: 0, duration: 0.5, easing: .default)
+    .add {
         state.offsetX = 10
         state.color = .red
     }
-    .append {
+    .add {
         state = AnimationState()
     }
     .start()
@@ -56,11 +55,11 @@ A handy function `commonConfig()` is also available, to set the common animation
 
 ```swift
 AnimationSequence()
-    .append {
+    .add {
         // ...
     }
-    .commonConfig(duration: 0.5, delay: 0, easing: .default)
-    .append {
+    .commonConfig(delay: 0, duration: 0.5, easing: .default)
+    .add {
         // ...
     }
     .start()
@@ -73,37 +72,37 @@ Any non-given value will be default to globals or fallback to `AnimationDefaults
 ```swift
 AnimationSequence()
     // only this animation will have duration of 0.5
-    .append(duration: 0.5) {
+    .add(duration: 0.5) {
         state.offsetX = 10
         state.color = .red
     }
     // only this animation will have delay of 0.3
-    .append(delay: 0.3) {
+    .add(delay: 0.3) {
         state = AnimationState()
     }
     .start()
 ```
 
 ### Async
-Appending animations will always keep them one after the other, but in case you need an animation triggered but not awaited, async is the solution. Let's pictures the animation sequence as follows:
+Adding animations will always keep them one after the other, but in case you need an animation to be triggered but not awaited, `async` is the solution. Let's picture the animation sequence as follows:
 ```swift
  (A)==>(B)==|      |==>(E)
             |==>(C)
             |==>(D)
 
-// Animation A starts, then comes B, at that moment, we trigger C and D without waiting for them.
-// then finally, right after B, comes E and the sequence ends.
+// Animation A starts, A finishes, B starts, B finishes,
+// C and D are triggered, E starts and finishes the sequence.
 ```
 
 ```swift
 AnimationSequence()
     // 1. First animation block
-    .append {
+    .add {
         state.offsetX = 10
         state.color = .red
     }
-    // this animation is triggered but never awaited.
-    // It's simply skipped from the sequence
+    // this animation is triggered after 1. but never awaited.
+    // It's simply skept from the sequence
     .async {
         state.scale = 1.5
     }
@@ -113,26 +112,26 @@ AnimationSequence()
         state.opacity = 0.5
     }
     // 2. This animation block will start right after number 1 is done.
-    .append {
+    .add {
         state = AnimationState()
     }
     .start()
 ```
 
 ### Wait
-Sometimes a small waiting time is needed, but we don't want to modify the next animation's delay, because that's annoying to be adding and subtracting small double values. For that, there is a `wait()` function that simply does the process I just explained.
+Sometimes a small waiting time is needed, but we don't want to modify the next animation's delay, because that's annoying to be adding and subtracting small double values. For that, there is a `wait()` function that simplifies the process I just explained.
 
 ```swift
 AnimationSequence()
-    .append {
+    .add {
         state.offsetX = 10
         state.color = .red
     }
-    // using this function is better than appending
-    // an empty animation block. wait() will add the delay
-    // to the next block, instead of triggering a new animation
+    // using this function is better than adding
+    // an empty animation block, since wait() will add the delay
+    // to the next block, instead of triggering a new empty animation
     .wait(for: 0.2)
-    .append {
+    .add {
         state = AnimationState()
     }
     .start()
@@ -147,10 +146,6 @@ AnimationSequence()
     .start()
 ```
 
-## To do
-- Debug more animation details
-- Create project sample
-
 ## Contribution
 
-If you find the project interesting, catch any mistakes I've made, or just see room for improvement, feel free to fork and contribute, I'll be more than happy.
+If you find the project interesting, catch any mistakes I've made, or just see any room for improvement, feel free to fork and contribute, I'll be more than happy.

--- a/Sources/AnimationSequence/AnimationConfiguration.swift
+++ b/Sources/AnimationSequence/AnimationConfiguration.swift
@@ -10,35 +10,54 @@ public enum AnimationEasing {
     case custom(animation: Animation)
 }
 
-// small convenient alias to avoid typing the closure signature everywhere
+// Used to provide animation blocks, and any type of callback
 public typealias AnimationBlock = () -> Void
-
 
 // MARK: - Default values
 
 public struct AnimationDefaults {
-    public static let defaultDuration: Double = 0.1
     public static let defaultDelay: Double = 0
+    public static let defaultDuration: Double = 0.1
     public static let defaultEasing: AnimationEasing = .default
 }
 
-public class AnimationConfiguration {
+public class AnimationConfiguration: CustomStringConvertible {
     
     // MARK: - Properties
     
-    public var duration: Double
+    public var label: String
     public var delay: Double
+    public var duration: Double
     public var easing: AnimationEasing
-    public var block: AnimationBlock?
-    public var isAsync: Bool = false
+    public var animation: AnimationBlock?
+    public var isAsync: Bool
     
     // MARK: - Life cycle
     
-    public init(duration: Double, delay: Double, easing: AnimationEasing, block: AnimationBlock? = nil) {
-        self.duration = duration
+    public init(
+        label: String,
+        delay: Double,
+        duration: Double,
+        easing: AnimationEasing, 
+        animation: AnimationBlock? = nil,
+        isAsync: Bool = false
+    ) {
+        self.label = label
         self.delay = delay
+        self.duration = duration
         self.easing = easing
-        self.block = block
+        self.animation = animation
+        self.isAsync = isAsync
+    }
+    
+    public var description: String {
+        return [
+            "[label: \(label)",
+            "delay: \(delay)",
+            "duration: \(duration)",
+            "easing: \(easing)",
+            "isAsync: \(isAsync)]"
+        ].joined(separator: "\t")
     }
 }
 


### PR DESCRIPTION
- When only one async animation was provided, the delay time was wrong
- Renames `append` to `add`
- Moves `delay` before `duration`
- Improves documentation
- Adds labels to animation blocks